### PR TITLE
Add backend api tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "start": "node dist/index.js",
     "dev": "node --loader ts-node/esm src/index.ts",
     "build": "tsc"
@@ -20,20 +20,26 @@
     "@neondatabase/serverless": "^0.6.0",
     "@prisma/client": "^6.15.0",
     "bcrypt": "^6.0.0",
-    "dotenv": "^17.2.2",
+    "dotenv": "^16.4.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "langchain": "^0.3.32",
     "redis": "^5.8.2"
+  },
+  "overrides": {
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^24.3.0",
+    "@types/supertest": "^2.0.16",
     "prisma": "^6.15.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "supertest": "^6.3.4",
+    "vitest": "^2.0.5"
   }
 }

--- a/server/src/__tests__/auth.protected.test.ts
+++ b/server/src/__tests__/auth.protected.test.ts
@@ -1,0 +1,45 @@
+import request from 'supertest';
+import app from '../app.js';
+import jwt from 'jsonwebtoken';
+
+vi.mock('../db/prisma.js', () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    }
+  }
+}));
+
+const JWT_SECRET = process.env.JWT_SECRET || 'supersecretkey';
+
+function tokenFor(userId: number) {
+  return jwt.sign({ userId }, JWT_SECRET, { expiresIn: '15m' });
+}
+
+describe('Protected user endpoints should require auth', () => {
+  it('GET /api/user/profile without token returns 401', async () => {
+    const res = await request(app).get('/api/user/profile');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /api/user/profile with token returns user profile', async () => {
+    const prisma = (await import('../db/prisma.js')).default as any;
+    (prisma.user.findUnique as any).mockResolvedValue({
+      id: 42,
+      email: 'x@y.com',
+      username: 'x',
+      password: 'redacted',
+      preferences: null,
+      dietaryGoals: [],
+    });
+
+    const res = await request(app)
+      .get('/api/user/profile')
+      .set('Authorization', `Bearer ${tokenFor(42)}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('user');
+    expect(res.body.user.id).toBe(42);
+  });
+});

--- a/server/src/__tests__/auth.public.test.ts
+++ b/server/src/__tests__/auth.public.test.ts
@@ -1,0 +1,56 @@
+import request from 'supertest';
+import app from '../app.js';
+
+vi.mock('../db/prisma.js', () => ({
+  default: {
+    user: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn()
+    }
+  }
+}));
+
+vi.mock('../langchain/redisClient.js', () => ({
+  redis: {
+    on: vi.fn(),
+    connect: vi.fn(),
+    get: vi.fn(),
+    set: vi.fn(),
+  }
+}));
+
+describe('Auth APIs', () => {
+  it('POST /api/auth/signup should validate and create user', async () => {
+    const prisma = (await import('../db/prisma.js')).default as any;
+    (prisma.user.findUnique as any).mockResolvedValue(null);
+    (prisma.user.create as any).mockResolvedValue({ id: 1, email: 'a@b.com', username: 'alice', password: 'hashed', profile_completed: false });
+    (prisma.user.update as any).mockResolvedValue({});
+
+    const res = await request(app)
+      .post('/api/auth/signup')
+      .send({ username: 'alice', email: 'a@b.com', password: 'secret' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('accessToken');
+    expect(res.body).toHaveProperty('refreshToken');
+    expect(res.body.user.email).toBe('a@b.com');
+  });
+
+  it('POST /api/auth/signin should return tokens for valid creds', async () => {
+    const prisma = (await import('../db/prisma.js')).default as any;
+    const bcrypt = await import('bcrypt');
+
+    (prisma.user.findUnique as any).mockResolvedValue({ id: 2, email: 'c@d.com', username: 'carl', password: await bcrypt.hash('pw', 1), profile_completed: false });
+    (prisma.user.update as any).mockResolvedValue({});
+
+    const res = await request(app)
+      .post('/api/auth/signin')
+      .send({ email: 'c@d.com', password: 'pw' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('accessToken');
+    expect(res.body).toHaveProperty('refreshToken');
+    expect(res.body.user.email).toBe('c@d.com');
+  });
+});

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -1,0 +1,10 @@
+import request from 'supertest';
+import app from '../app.js';
+
+describe('Health root endpoint', () => {
+  it('GET / should return greeting', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Hello, TypeScript + Express');
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,27 @@
+import express, { type Request, type Response } from "express";
+import router from "./routes/auth.routes.js";
+import goal_router from "./routes/goal.routes.js";
+import meal_logs from "./routes/meals.routes.js";
+import preference from "./routes/preferences.routes.js";
+import recommend_router from "./routes/recommend.route.js";
+import main_router from "./routes/mainController.routes.js";
+import analytics from "./routes/analytics.routes.js";
+import user_router from "./routes/user.routes.js";
+
+const app = express();
+
+app.get("/", (req: Request, res: Response) => {
+  res.send("Hello, TypeScript + Express + Live Reload!");
+});
+
+app.use(express.json());
+app.use('/api/auth', router);
+app.use('/api/goals', goal_router);
+app.use('/api/meals', meal_logs);
+app.use('/api/preference', preference);
+app.use('/api/recommend', recommend_router);
+app.use('/api/complete_profile', main_router);
+app.use('/api/analytics', analytics);
+app.use('/api/user', user_router);
+
+export default app;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,28 +1,7 @@
-import express, { type Request, type Response } from "express";
-import router from "./routes/auth.routes.js";
-import goal_router from "./routes/goal.routes.js";
-import meal_logs from "./routes/meals.routes.js";
-import preference from "./routes/preferences.routes.js";
-import recommend_router from "./routes/recommend.route.js";
-import main_router from "./routes/mainController.routes.js";
-import analytics from "./routes/analytics.routes.js";
-import user_router from "./routes/user.routes.js";
+import app from "./app.js";
 
-const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.get("/", (req: Request, res: Response) => {
-    res.send("Hello, TypeScript + Express + Live Reload!");
-});
-app.use(express.json());
-app.use('/api/auth', router);
-app.use('/api/goals', goal_router);
-app.use('/api/meals', meal_logs);
-app.use('/api/preference', preference);
-app.use('/api/recommend', recommend_router);
-app.use('/api/complete_profile', main_router);
-app.use('/api/analytics', analytics);
-app.use('/api/user', user_router);
 app.listen(PORT, () => {
-    console.log(`...Server running at http://localhost:${PORT}`);
+  console.log(`...Server running at http://localhost:${PORT}`);
 });

--- a/server/src/langchain/embeddings.ts
+++ b/server/src/langchain/embeddings.ts
@@ -2,8 +2,14 @@ import { GoogleGenerativeAIEmbeddings } from "@langchain/google-genai";
 import { TaskType } from "@google/generative-ai";
 import dotenv from 'dotenv';
 dotenv.config();
-export const embeddings = new GoogleGenerativeAIEmbeddings({
-    model: "text-embedding-004", // 768 dimensions
-    taskType: TaskType.RETRIEVAL_DOCUMENT,
-    title: "langchain-vetors",
-});
+
+export const embeddings: any = (process.env.NODE_ENV === 'test')
+  ? {
+      embedQuery: async () => [0],
+      embedDocuments: async () => [[0]],
+    }
+  : new GoogleGenerativeAIEmbeddings({
+      model: "text-embedding-004", // 768 dimensions
+      taskType: TaskType.RETRIEVAL_DOCUMENT,
+      title: "langchain-vetors",
+    });

--- a/server/src/langchain/model/model.ts
+++ b/server/src/langchain/model/model.ts
@@ -1,7 +1,15 @@
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import dotenv from 'dotenv'
 dotenv.config()
-export const model = new ChatGoogleGenerativeAI({
-    model: "gemini-2.0-flash",
-    temperature: 0
-});
+
+// During tests, export a lightweight stub to avoid requiring API keys
+export const model: any = (process.env.NODE_ENV === 'test')
+  ? {
+      // LLMChain uses `invoke` under the hood
+      invoke: async () => ({ content: 'stubbed response' }),
+      call: async () => ({ text: 'stubbed response' }),
+    }
+  : new ChatGoogleGenerativeAI({
+      model: "gemini-2.0-flash",
+      temperature: 0
+    });

--- a/server/src/langchain/redisClient.ts
+++ b/server/src/langchain/redisClient.ts
@@ -11,4 +11,8 @@ export const redis = createClient({
 });
 
 redis.on('error', (err) => console.log('Redis Client Error', err));
-await redis.connect();
+
+// Avoid connecting to Redis during tests
+if (process.env.NODE_ENV !== 'test') {
+    await redis.connect();
+}

--- a/server/src/langchain/vector.ts
+++ b/server/src/langchain/vector.ts
@@ -2,6 +2,13 @@ import { NeonPostgres } from "@langchain/community/vectorstores/neon";
 import { embeddings } from './embeddings.js';
 
 export async function loadVectorStore() {
+  if (process.env.NODE_ENV === 'test') {
+    // Minimal stub for tests
+    return {
+      similaritySearchWithScore: async () => [],
+      addDocuments: async () => {},
+    } as any;
+  }
   return await NeonPostgres.initialize(embeddings, {
     connectionString: process.env.DATABASE_URL as string,
   });

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+    exclude: ['node_modules', 'dist'],
+  },
+});


### PR DESCRIPTION
Add backend API tests using Vitest and Supertest to ensure API functionality and establish a robust testing framework.

The Express app was refactored to export the `app` instance, enabling `supertest` to test endpoints without starting a full server. External dependencies like Prisma, Redis, and LangChain (LLM/embeddings/vector store) are mocked or guarded to ensure tests are fast, isolated, and don't require external service connections or API keys.

---
<a href="https://cursor.com/background-agent?bcId=bc-03f838dc-215c-4a93-a092-8db5480a2651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-03f838dc-215c-4a93-a092-8db5480a2651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

